### PR TITLE
Annotate thrown errors with their file of origin

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,9 +109,15 @@ function combynify(file, settings) {
   }
 
   return through(parts, function(callback) {
-    processTemplate.call(this, chunks.join(''), settings, function(template) {
-      callback();
-    });
+    try {
+      processTemplate.call(this, chunks.join(''), settings, function(template) {
+        callback();
+      });
+    } catch( err ) {
+      // Annotate error with the file in which it originated
+      err.message = err.message + ' in ' + file;
+      throw err;
+    }
   });
 }
 


### PR DESCRIPTION
This may not be the best manner in which to do this, but it's difficult while authoring several templates at once that the file is not noted in the stack trace thrown by Combyne—the error is rarely informative enough to know which file is causing the problem. (I ran into this during a migration to Combyne, so many files were in play at once; this is less of an issue when implementing template files sequentially.)
